### PR TITLE
tweaks to the new exercise page

### DIFF
--- a/front_end/server/handlers/ExerciseHandler.py
+++ b/front_end/server/handlers/ExerciseHandler.py
@@ -88,6 +88,12 @@ class ExerciseHandler(BaseUserHandler):
 
                 if is_new_ui:
                     args['presubmission'] = self.content.get_presubmission(course, assignment, exercise, self.get_user_id())
+
+                    exercise_details['show_instructor_solution'] = bool(exercise_details['show_instructor_solution'] and (exercise_details['solution_code'] != "" or exercise_details['solution_description'] != ""))
+                    del exercise_details['solution_code']
+                    del exercise_details['solution_description']
+
+                    args['exercise_details'] = exercise_details
                     self.render("spa.html", template_variables=args, **args)
                 else:
                     self.render("exercise.html", **args)

--- a/front_end/ui/pages/exercise/ExerciseApp.ts
+++ b/front_end/ui/pages/exercise/ExerciseApp.ts
@@ -96,6 +96,7 @@ export default class ExerciseApp extends LitElement {
 								<tests-pane 
 									.getCode=${this.getUserCode} 
 									.addSubmission=${this.addSubmission}
+									.hasPassingSubmission=${this.hasPassingSubmission}
 								></tests-pane>
 							`}
 						>
@@ -205,6 +206,11 @@ export default class ExerciseApp extends LitElement {
 		const newSession = this.sessions[this.userCodeFileName];
 		newSession.setValue(oldSession.getValue());
 		this.onFileSelected(this.userCodeFileName);
+	}
+
+
+	get hasPassingSubmission(): boolean {
+		return !!this.submissions?.find((submission) => !!submission.passed);
 	}
 }
 

--- a/front_end/ui/pages/exercise/components/TestsPane.scss
+++ b/front_end/ui/pages/exercise/components/TestsPane.scss
@@ -47,25 +47,9 @@ tests-pane {
 		tbody {
 			tr {
 				cursor: pointer;
-
-				&.passed {
-					background-color: #bfdebea7 !important;
-					&:hover {
-						background-color: #abd9a9a7 !important;
-					}
-					td {
-						border-bottom-color: rgb(134, 134, 134);
-					}
-				}
 				
-				&.failed {
-					background-color: #d9b4b499 !important;
-					&:hover {
-						background-color: #d89f9f99 !important;
-					}
-					td {
-						border-bottom-color: rgb(134, 134, 134);
-					}
+				.modal {
+					cursor: default;
 				}
 			}
 		}
@@ -74,6 +58,10 @@ tests-pane {
 
 test-results-modal {
 	display: flex;
+
+	pre {
+		font-size: 16px;
+	}
 
 	>button:first-child {
 		margin-right: 8px;
@@ -94,7 +82,7 @@ test-results-modal {
 		display: flex;
 		flex-direction: column;
 
-		#accordion {
+		.collapsible-section {
 			flex: 1;
 			display: flex;
 			flex-direction: column;
@@ -141,7 +129,7 @@ test-results-modal {
 				height: 41px;
 	
 				a {
-					text-decoration: none;
+					text-decoration: none !important;
 				}
 			}
 		}


### PR DESCRIPTION
This should resolve most of the issues you mentioned, but there are a few I wanted to talk about.

I ended up removing the background color from the test table, and the border didn't look great either. I'm hoping the icon and it's color are enough to show it's status.

I had to leave the student's code output at the end of the test details modal like you originally wanted, but I made it so it will remember each test's collapse state between opening the closing, which I think will he good too! It had to be the last one so that the diff output could take up the full height.

I think it's possible to change the pair programming partner selection somehow, but it doesn't seem right next to the run button. I want to think about this a little bit more before changing it, but I did make it remember who you selected.

I'm not sure what you mean by making sure the nav bar is always at the top, I haven't found a way to get into a state where you can scroll the whole page. Can you show me how you did this?