### PR TITLE
do not rely on content-length headers

### DIFF
--- a/front_end/ui/utils/request.ts
+++ b/front_end/ui/utils/request.ts
@@ -7,18 +7,22 @@ export async function postFormData<T>(url: string, data: any): Promise<T> {
 		method: "POST",
 		body: formData,
 	});
-	if (Number(response.headers.get('Content-Length')) > 0) {
+	try {
 		return await response.json();
+	} catch (e) {
+		console.error(e);
+		return null as any;
 	}
-	return null as any;
 }
 
 export async function get<T>(url: string): Promise<T> {
 	const response = await fetch(url, {
 		method: "GET",
 	});
-	if (Number(response.headers.get('Content-Length')) > 0) {
+	try {
 		return await response.json();
+	} catch (e) {
+		console.error(e);
+		return null as any;
 	}
-	return null as any;
 }


### PR DESCRIPTION
If the backend returns an empty response (like ti does for some endpoints) converting it to JSON will fail. That's why we were checking for the Content-Length before trying to convert the response to JSON. But this way the error will just be caught and it should behave the same way.

I don't know yet why we aren't getting back Content-Length headers in production, but this makes it so we don't need them.